### PR TITLE
Enable changing read_timeout for HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ MangoPay.configure do |c|
   c.preproduction = true
   c.client_id = 'YOUR_CLIENT_ID'
   c.client_passphrase = 'YOUR_CLIENT_PASSWORD'
+  c.read_timeout = 120 # seconds
 end
 
 

--- a/lib/generators/templates/mangopay.rb.erb
+++ b/lib/generators/templates/mangopay.rb.erb
@@ -2,4 +2,5 @@ MangoPay.configure do |c|
   c.preproduction = <%= options[:preproduction] %>
   c.client_id = '<%= @client_id %>'
   c.client_passphrase = '<%= @client_passphrase %>'
+  c.read_timeout = 120 # seconds
 end

--- a/lib/mangopay.rb
+++ b/lib/mangopay.rb
@@ -37,10 +37,14 @@ module MangoPay
   class Configuration
     attr_accessor :preproduction, :root_url,
                   :client_id, :client_passphrase,
-                  :temp_dir
+                  :temp_dir, :read_timeout
 
     def preproduction
       @preproduction || false
+    end
+
+    def read_timeout
+      @read_timeout || 60
     end
 
     def root_url
@@ -78,7 +82,7 @@ module MangoPay
       uri = api_uri(url)
       uri.query = URI.encode_www_form(filters) unless filters.empty?
 
-      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: configuration.read_timeout) do |http|
         req = Net::HTTP::const_get(method.capitalize).new(uri.request_uri, headers)
         req.body = JSON.dump(params)
         before_request_proc.call(req) if before_request_proc


### PR DESCRIPTION
This gem uses the [Net::HTTP](http://ruby-doc.org/stdlib-2.2.0/libdoc/net/http/rdoc/Net/HTTP.html) library to make HTTP requests. By default this library has a read_timeout set to 60 seconds.

As production users of MangoPay API, we've seen how the API sometimes takes more than 60 seconds to respond. This is currently affecting different kind of operations, including PayIn, Refund and Transfers between wallets.  

Obviously, having to wait more than 60 seconds for a response from the API is not ideal, but having  `Net::HTTP` firing a timeout is even worse, because when that happens, MangoPay will continue processing the operation, but your app won't ever get noticed of the result, causing multiple kind of issues such as duplicated payments, which means angry customers.

This PR let gem users to increase the timeout of `Net::HTTP` from `MangoPay.configure` block:

```ruby
MangoPay.configure do |c|
  c.read_timeout = 120 # seconds
end
```