### PR TITLE
fetch documents without an user

### DIFF
--- a/lib/mangopay/kyc_document.rb
+++ b/lib/mangopay/kyc_document.rb
@@ -15,7 +15,8 @@ module MangoPay
 
       # Fetches the KYC document belonging to the given +user_id+, with the given +document_id+.
       def fetch(user_id, document_id)
-        MangoPay.request(:get, url(user_id, document_id))
+        url = (user_id) ? url(user_id, document_id) : "#{MangoPay.api_path}/KYC/documents/#{CGI.escape(document_id.to_s)}"
+        MangoPay.request(:get, url)
       end
 
       # Fetches list of KYC documents:

--- a/spec/mangopay/kyc_document_spec.rb
+++ b/spec/mangopay/kyc_document_spec.rb
@@ -26,6 +26,11 @@ describe MangoPay::KycDocument do
       document = MangoPay::KycDocument.fetch(new_natural_user['Id'], new_document['Id'])
       expect(document['Id']).to eq(new_document['Id'])
     end
+
+    it 'fetches a document just by id' do
+      document = MangoPay::KycDocument.fetch(nil, new_document['Id'])
+      expect(document['Id']).to eq(new_document['Id'])
+    end
   end
 
   describe 'FETCH ALL' do


### PR DESCRIPTION
As of v2.01 its possible to fetch documents without 
specifying a user_id, this PR reflects that change on 
the level of `KycDocument`. Although this is just a quick
win, i'd suggest to have `KycDocument#fetch` only accept
`document_id` if future versions.

Fetching documents on a per user level should live
inside `User`, like it is already for `cards`, `wallets` and
`transactions`. 

What do you think?

