### PR TITLE
ExtendedPayIn supported

### DIFF
--- a/lib/mangopay/pay_in.rb
+++ b/lib/mangopay/pay_in.rb
@@ -13,6 +13,17 @@ module MangoPay
         def self.url(*)
           "#{MangoPay.api_path}/payins/card/#{CGI.escape(class_name.downcase)}"
         end
+
+        def self.extended(pay_in_id)
+          MangoPay.request(:get, extended_url(pay_in_id), {}, {})
+        end
+
+        # See https://docs.mangopay.com/endpoints/v2.01/payins#e847_view-card-details-for-a-payin-web
+        # example: data = MangoPay::PayIn::Card::Web.extended(12639078)
+        def self.extended_url(pay_in_id)
+          escaped_pay_in_id = CGI.escape(pay_in_id.to_s)
+          "#{MangoPay.api_path}/payins/card/web/#{escaped_pay_in_id}/extended"
+        end
       end
 
       # See http://docs.mangopay.com/api-references/payins/payindirectcard/

--- a/spec/mangopay/payin_card_web_spec.rb
+++ b/spec/mangopay/payin_card_web_spec.rb
@@ -22,6 +22,15 @@ describe MangoPay::PayIn::Card::Web, type: :feature do
     end
   end
 
+  describe 'EXTENDED' do
+    context 'when resource not exists' do
+      it 'fetches extended information' do
+        expect { MangoPay::PayIn::Card::Web.extended(1000000) }.to \
+          raise_error(MangoPay::ResponseError)
+      end
+    end
+  end
+
   describe 'FETCH' do
     it 'fetches a payin' do
       created = new_payin_card_web


### PR DESCRIPTION
Implement: https://docs.mangopay.com/endpoints/v2.01/payins#e847_view-card-details-for-a-payin-web :)

```ruby
data = MangoPay::PayIn::Card::Web.extended(12639078)
```
