### PR TITLE
Added support for KYC and dispute document pages consultation.

### DIFF
--- a/lib/mangopay/dispute.rb
+++ b/lib/mangopay/dispute.rb
@@ -125,6 +125,18 @@ module MangoPay
         end
       end
 
+      # Creates temporary URLs where each page of
+      # a dispute document can be viewed.
+      #
+      # @param +document_id+ ID of the document whose pages to consult
+      # @return Array of consults for viewing the dispute document's pages
+      def create_document_consult(document_id)
+        MangoPay.request(:get, consult_url(document_id), {}, {})
+      end
+
+      def consult_url(document_id)
+        "#{MangoPay.api_path}/dispute-documents/#{document_id}/consult"
+      end
     end
   end
 end

--- a/lib/mangopay/kyc_document.rb
+++ b/lib/mangopay/kyc_document.rb
@@ -65,6 +65,19 @@ module MangoPay
           "#{MangoPay.api_path}/users/#{CGI.escape(user_id.to_s)}/KYC/documents"
         end
       end
+
+      # Creates temporary URLs where each page of
+      # a KYC document can be viewed.
+      #
+      # @param +document_id+ ID of the document whose pages to consult
+      # @return Array of consults for viewing the KYC document's pages
+      def create_documents_consult(document_id)
+        MangoPay.request(:post, consult_url(document_id), {}, {})
+      end
+
+      def consult_url(document_id)
+        "#{MangoPay.api_path}/KYC/documents/#{document_id}/consult"
+      end
     end
   end
 end

--- a/spec/mangopay/dispute_spec.rb
+++ b/spec/mangopay/dispute_spec.rb
@@ -214,6 +214,18 @@ and it's infact not suitable like that
     end
   end
 
+  # TODO: Run this test when possible
+  it 'create_document_consult fetches a list of document page consults' do
+    fnm = __FILE__.sub('.rb', '.png')
+    disp = find_dispute
+    doc = create_doc(disp)
+    MangoPay::Dispute.create_document_page(disp['Id'], doc['Id'], nil, fnm)
+    consults = MangoPay::Dispute.create_document_consult(doc['Id'])
+
+    expect(consults).not_to be_nil
+    expect(consults).to be_kind_of(Array)
+  end
+
   def test_contest_dispute
       dispute = @disputes.find do |disp|
         ['PENDING_CLIENT_ACTION', 'REOPENED_PENDING_CLIENT_ACTION'].include?(disp['Status']) &&

--- a/spec/mangopay/kyc_document_spec.rb
+++ b/spec/mangopay/kyc_document_spec.rb
@@ -102,5 +102,16 @@ describe MangoPay::KycDocument do
         expect(err.type).to eq 'param_error'
       }
     end
+
+    describe 'CREATE CONSULT' do
+      it 'creates document pages consult' do
+        fnm = __FILE__.sub('.rb', '.png')
+        MangoPay::KycDocument.create_page(new_natural_user['Id'], new_document['Id'], nil, fnm)
+
+        consult = MangoPay::KycDocument.create_documents_consult(new_document['Id'])
+        expect(consult).not_to be_nil
+        expect(consult).to be_kind_of(Array)
+      end
+    end
   end
 end


### PR DESCRIPTION
Note: Added tests for both cases (KYC / dispute), but was only able to run the KYC documents test, due to the special conditions necessary for the dispute documents tests.