### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require 'mangopay'
 MangoPay.configure do |c|
   c.preproduction = true
   c.client_id = 'YOUR_CLIENT_ID'
-  c.client_passphrase = 'YOUR_CLIENT_PASSWORD'
+  c.client_apiKey = 'YOUR_CLIENT_API_KEY'
   c.log_file = File.join('mypath', 'mangopay.log')
   c.http_timeout = 10000
 end


### PR DESCRIPTION
Updates the readme as `client_passphrase` no longer exists, instead, you must use `client_apiKey` in the latest version of the gem.