### PR TITLE
Handle error response when doing an auth call

### DIFF
--- a/lib/mangopay/errors.rb
+++ b/lib/mangopay/errors.rb
@@ -49,12 +49,17 @@ module MangoPay
     end
 
     def type;    @details['Type']; end
-    def errors;  @details['errors']; end
+    def error;   @details['error']; end
+    def errors;  @details['errors'] || error; end
 
     def message;
-      msg = @details['Message']
-      msg += errors.sort.map {|k,v| " #{k}: #{v}"}.join if (errors && errors.is_a?(Hash))
-      msg
+      if error
+        msg = error
+      else
+        msg = @details['Message']
+        msg += errors.sort.map {|k,v| " #{k}: #{v}"}.join if (errors && errors.is_a?(Hash))
+        msg
+      end
     end
 
   end

--- a/spec/mangopay/configuration_spec.rb
+++ b/spec/mangopay/configuration_spec.rb
@@ -6,7 +6,11 @@ describe MangoPay::Configuration do
       c.client_id = 'test_asd'
       c.client_apiKey = '00000'
       MangoPay::User.fetch()
-    }.to raise_error(MangoPay::ResponseError)
+    }.to raise_error { |err|
+        expect(err).to be_a MangoPay::ResponseError
+        expect(err.code).to eq '401'
+        expect(err.message).to eq 'invalid_client'
+      }
   end
 
   it 'goes ok when calling with correct client credentials' do


### PR DESCRIPTION
It turned out that sometimes the API answers with an `error` instead of `errors` and `type`. It's not really returning a message, so I proposed to just take the error in the message, even though it looks more like a `type` than a `Message`.

It's necessary to handle it because otherwise users just get an empty ResponseError object, with not a single idea of what's going wrong.
Maybe it's just needed for the API to answer with similar response than other calls, and this diff would be useless then :)