### PR TITLE
Extend `fetch_wallet` and `create_payout` API.

### DIFF
--- a/lib/mangopay/client.rb
+++ b/lib/mangopay/client.rb
@@ -47,7 +47,10 @@ module MangoPay
       # +currency_iso_code+ is currncy ISO code
       # see https://docs.mangopay.com/api-references/client-wallets/
       def fetch_wallet(funds_type, currency_iso_code)
-        MangoPay.request(:get, url() + "/wallets/#{funds_type}/#{currency_iso_code}")
+        method = :get
+        path = url() + "/wallets/#{funds_type}/#{currency_iso_code}"
+        yield method, path if block_given?
+        MangoPay.request(method, path)
       end
 
       # Fetch transactions for all your client wallets.
@@ -79,7 +82,10 @@ module MangoPay
       end
 
       def create_payout(params)
-        MangoPay.request(:post, url() + "/payouts", params)
+        method = :post
+        path = url() + "/payouts"
+        yield method, path, params if block_given?
+        MangoPay.request(method, path, params)
       end
 
     end


### PR DESCRIPTION
The methods `fetch_wallet` and `create_payout` can now take a block. 

`fetch_wallet` yields `method` and path:

```
response = MangoPay::Client.fetch_wallet(:fees, 'EUR') do |method, path|
  Rails.logger.info method
  Rails.logger.info path
end
```
`create_payout` also includes `params`:

```
response = MangoPay::Client.create_payout(payout_params) do |method, path, params|
  Rails.logger.info method
  Rails.logger.info path
  Rails.logger.info params
end
```