### PR TITLE
Add support for refund creation

### DIFF
--- a/lib/mangopay/refund.rb
+++ b/lib/mangopay/refund.rb
@@ -2,6 +2,7 @@ module MangoPay
 
   # See http://docs.mangopay.com/api-references/refund/
   class Refund < Resource
+    include HTTPCalls::Create
     include HTTPCalls::Fetch
 
     # Fetches list of refunds belonging to given +repudiation_id+


### PR DESCRIPTION
Add support to create refunds for PayIn, Transfer and PayOut transactions.

PayIn example
`MangoPay::PayIn.refund(pay_in_id, { AuthorId: user_id })`