### PR TITLE
Allow to fetch ubo declaration without user id

### DIFF
--- a/lib/mangopay/ubo_declaration.rb
+++ b/lib/mangopay/ubo_declaration.rb
@@ -14,7 +14,7 @@ module MangoPay
         MangoPay.request(:post, url(user_id), {}, {}, idempotency_key)
       end
 
-      # Fetches the Ubo declaration belonging to the given +user_id+ if given, with the given +document_id+.
+      # Fetches the Ubo declaration belonging to the given +user_id+ if given, with the given +id+.
       def fetch(user_id, id, idempotency_key)
         url = (user_id) ? url(user_id, id) : "#{MangoPay.api_path}/kyc/ubodeclarations/#{CGI.escape(id.to_s)}"
         MangoPay.request(:get, url, {}, {}, idempotency_key)

--- a/lib/mangopay/ubo_declaration.rb
+++ b/lib/mangopay/ubo_declaration.rb
@@ -14,8 +14,10 @@ module MangoPay
         MangoPay.request(:post, url(user_id), {}, {}, idempotency_key)
       end
 
+      # Fetches the Ubo declaration belonging to the given +user_id+ if given, with the given +document_id+.
       def fetch(user_id, id, idempotency_key)
-        MangoPay.request(:get, url(user_id, id), {}, {}, idempotency_key)
+        url = (user_id) ? url(user_id, id) : "#{MangoPay.api_path}/kyc/ubodeclarations/#{CGI.escape(id.to_s)}"
+        MangoPay.request(:get, url, {}, {}, idempotency_key)
       end
 
       def update(user_id, id, params = {}, idempotency_key)

--- a/spec/mangopay/ubo_declaration_spec.rb
+++ b/spec/mangopay/ubo_declaration_spec.rb
@@ -14,6 +14,17 @@ describe MangoPay::UboDeclaration do
       expect(ubo_declaration_byId).not_to be_nil
     end
 
+    it 'fetches ubo declaration just by id' do
+      legal_user = new_legal_user
+
+      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+
+      ubo_declaration_byId = MangoPay::UboDeclaration.fetch(nil, ubo_declaration['Id'], nil)
+
+      expect(ubo_declaration).not_to be_nil
+      expect(ubo_declaration_byId).not_to be_nil
+    end
+
     describe 'UPDATE' do
       it 'can update a UBO declaration' do
         legal_user = new_legal_user


### PR DESCRIPTION
Similar way as [KYC document fetching](https://github.com/Mangopay/mangopay2-ruby-sdk/blob/master/lib/mangopay/kyc_document.rb#L18) works allowing to fetch ubo declaration without specifying user id, only by declaration id.

You can now do:
```ruby
MangoPay::UboDeclaration.fetch(nil, ubo_declaration_id, nil)
```
When you don't have user_id, for example, when webhook about ubo_declaration was sent from MangoPay, where only ubo id is present, and client wants to fetch resource