### PR TITLE
Make idempotency key not required for UBO declarations

### DIFF
--- a/lib/mangopay/ubo_declaration.rb
+++ b/lib/mangopay/ubo_declaration.rb
@@ -10,17 +10,17 @@ module MangoPay
         end
       end
 
-      def create(user_id, idempotency_key)
+      def create(user_id, idempotency_key = nil)
         MangoPay.request(:post, url(user_id), {}, {}, idempotency_key)
       end
 
       # Fetches the Ubo declaration belonging to the given +user_id+ if given, with the given +id+.
-      def fetch(user_id, id, idempotency_key)
+      def fetch(user_id, id, idempotency_key = nil)
         url = (user_id) ? url(user_id, id) : "#{MangoPay.api_path}/kyc/ubodeclarations/#{CGI.escape(id.to_s)}"
         MangoPay.request(:get, url, {}, {}, idempotency_key)
       end
 
-      def update(user_id, id, params = {}, idempotency_key)
+      def update(user_id, id, params = {}, idempotency_key = nil)
         request_params = {
             Status: params['Status'],
             Ubos: params['Ubos']

--- a/spec/mangopay/ubo_declaration_spec.rb
+++ b/spec/mangopay/ubo_declaration_spec.rb
@@ -6,9 +6,9 @@ describe MangoPay::UboDeclaration do
     it 'can fetch a UBO declaration' do
       legal_user = new_legal_user
 
-      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'])
 
-      ubo_declaration_byId = MangoPay::UboDeclaration.fetch(legal_user['Id'], ubo_declaration['Id'], nil)
+      ubo_declaration_byId = MangoPay::UboDeclaration.fetch(legal_user['Id'], ubo_declaration['Id'])
 
       expect(ubo_declaration).not_to be_nil
       expect(ubo_declaration_byId).not_to be_nil
@@ -28,13 +28,13 @@ describe MangoPay::UboDeclaration do
     describe 'UPDATE' do
       it 'can update a UBO declaration' do
         legal_user = new_legal_user
-        ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+        ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'])
         ubo_declaration['Status'] = 'VALIDATION_ASKED'
 
         ubo = new_ubo(legal_user, ubo_declaration)
 
         ubo_declaration['Ubos'] = [ubo]
-        ubo_declaration = MangoPay::UboDeclaration.update(legal_user['Id'], ubo_declaration['Id'], ubo_declaration, nil)
+        ubo_declaration = MangoPay::UboDeclaration.update(legal_user['Id'], ubo_declaration['Id'], ubo_declaration)
 
         expect(ubo_declaration).not_to be_nil
         expect(ubo_declaration['Status']).to eq 'VALIDATION_ASKED'

--- a/spec/mangopay/ubo_spec.rb
+++ b/spec/mangopay/ubo_spec.rb
@@ -5,7 +5,7 @@ describe MangoPay::Ubo do
   describe 'FETCH' do
     it 'can fetch a Ubo' do
       legal_user = new_legal_user
-      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'])
       ubo = new_ubo(legal_user, ubo_declaration)
       result = MangoPay::Ubo.fetch(legal_user['Id'], ubo_declaration['Id'], ubo['Id'])
       expect(result).not_to be_nil
@@ -16,7 +16,7 @@ describe MangoPay::Ubo do
   describe 'CREATE' do
     it 'can create a new Ubo' do
       legal_user = new_legal_user
-      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'])
       result = new_ubo(legal_user, ubo_declaration)
       expect(result).not_to be_nil
     end
@@ -25,7 +25,7 @@ describe MangoPay::Ubo do
   describe 'UPDATE' do
     it 'can update a Ubo' do
       legal_user = new_legal_user
-      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'], nil)
+      ubo_declaration = MangoPay::UboDeclaration.create(legal_user['Id'])
       ubo = new_ubo(legal_user, ubo_declaration)
       ubo['FirstName'] = 'Santa'
       ubo['LastName'] = 'Clause'


### PR DESCRIPTION
Not sure if this is by-design, but UboDeclaration actions require idempotency_key to be provided, even though `nil` can be passed as value. This is not the case with other resources.