### PR TITLE
BankingAliasesIBAN id method fixed

### DIFF
--- a/lib/mangopay/bankingaliases_iban.rb
+++ b/lib/mangopay/bankingaliases_iban.rb
@@ -8,9 +8,5 @@ module MangoPay
       MangoPay.request(:post, url, params, {}, headers_or_idempotency_key)
     end
 
-    def self.url(id = nil)
-      "#{super.url(id)}"
-    end
-
   end
 end

--- a/spec/mangopay/bankingaliases_iban_spec.rb
+++ b/spec/mangopay/bankingaliases_iban_spec.rb
@@ -1,0 +1,10 @@
+describe MangoPay::BankingAliasesIBAN do
+  include_context 'bankigaliases'
+
+  describe 'FETCH' do
+    it 'fetches a banking alias' do
+      bankingaliases = MangoPay::BankingAliasesIBAN.fetch(new_banking_alias['Id'])
+      expect(bankingaliases['Id']).to eq(new_banking_alias['Id'])
+    end
+  end
+end


### PR DESCRIPTION
Hello everybody

The class method `MangoPay::BankingAliasesIBAN.url` currently uses a bad syntax, which causes an error.

The `super` keyword in Ruby calls the superclass method. In this case, it returns a `String`.

`super.url(id)` leads to the following error

```
NoMethodError:
       undefined method `url' for "/v2.01/sdk-unit-tests/bankingaliases/163665005":String
```