### PR TITLE
CD config fix

### DIFF
--- a/.github/workflows/ruby_cd.yml
+++ b/.github/workflows/ruby_cd.yml
@@ -16,9 +16,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6.10
 


### PR DESCRIPTION
replaced 'actions/setup-ruby@v1' with 'ruby/setup-ruby@v1' and 'actions/checkout@v2' with 'actions/checkout@v3' for CD config