### PR TITLE
Allow to configure use_ssl option

### DIFF
--- a/lib/mangopay.rb
+++ b/lib/mangopay.rb
@@ -53,7 +53,7 @@ module MangoPay
                   :client_id, :client_apiKey,
                   :temp_dir, :log_file, :http_timeout,
                   :http_max_retries, :http_open_timeout,
-                  :logger
+                  :logger, :use_ssl
 
     def preproduction
       @preproduction || false
@@ -73,6 +73,14 @@ module MangoPay
 
     def http_open_timeout
       @http_open_timeout || 30
+    end
+
+    def use_ssl?
+      return true unless preproduction == true
+      return true unless defined?(@use_ssl)
+      return false if @use_ssl == false
+
+      true
     end
   end
 
@@ -150,7 +158,7 @@ module MangoPay
         headers['Idempotency-Key'] = headers_or_idempotency_key if headers_or_idempotency_key != nil
       end
 
-      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, :read_timeout => configuration.http_timeout,
+      res = Net::HTTP.start(uri.host, uri.port, :use_ssl => configuration.use_ssl?, :read_timeout => configuration.http_timeout,
                             :max_retries => configuration.http_max_retries,
                             :open_timeout => configuration.http_open_timeout, ssl_version: :TLSv1_2) do |http|
         req = Net::HTTP::const_get(method.capitalize).new(uri.request_uri, headers)

--- a/spec/mangopay/configuration_spec.rb
+++ b/spec/mangopay/configuration_spec.rb
@@ -19,6 +19,36 @@ describe MangoPay::Configuration do
     expect(users).to be_kind_of(Array)
   end
 
+  describe '.use_ssl?' do
+    let(:configuration) { MangoPay::Configuration.new }
+
+    it 'defaults to true' do
+      expect(configuration.use_ssl?).to eq(true)
+    end
+
+    context 'when assigned to false in production' do
+      before do
+        configuration.use_ssl = false
+        configuration.preproduction = false
+      end
+
+      it 'uses true as value' do
+        expect(configuration.use_ssl?).to eq(true)
+      end
+    end
+
+    context 'when assigned to false in preproduction' do
+      before do
+        configuration.use_ssl = false
+        configuration.preproduction = true
+      end
+
+      it 'uses assigned as value' do
+        expect(configuration.use_ssl?).to eq(false)
+      end
+    end
+  end
+
   describe 'logger' do
     around(:each) do |example|
       c = MangoPay.configuration


### PR DESCRIPTION
Hello,

we are trying to configure our testing environment and got stuck on forced `use_ssl` option as mandatory. As specs runs only locally (via docker) we are having hard time getting ssl certificate.

This PR allows to configure `use_ssl` option in preproduction enviroment. Production would be left unconfigurable as I believe ssl forcing is good thing in production.
In `preproduction` env without setting `use_ssl` option it would also default to `true` unless value is explicitly assigned to `false` 

@iulian03 