### PR TITLE
fix Psych::DisallowedClass error for ruby 3.1 and above

### DIFF
--- a/lib/mangopay/authorization_token.rb
+++ b/lib/mangopay/authorization_token.rb
@@ -66,7 +66,7 @@ module MangoPay
           f.flock(File::LOCK_SH)
           txt = f.read
           f.close
-          YAML.load(txt) || nil
+          YAML.safe_load(txt, permitted_classes: [Time]) || nil
         rescue Errno::ENOENT
           nil
         end


### PR DESCRIPTION
When running tests using ruby 3.1 or above, there is a problem with the loaded data from txt:

```
Failure/Error: YAML.load(txt) || nil
       
       Psych::DisallowedClass:
         Tried to load unspecified class: Time

...

200 examples, 183 failures, 2 pending
```

Tested from ruby 2.2.2 to 3.1.4