### PR TITLE
Add optional trace header logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.25.0] - 2024-04-16
+### Added
+
+- Add trace header logging : Introduced the `log_trace_headers` boolean configuration key. Set it to true to enable logging of `x_mangopay_trace-id` and `IdempotencyKey` in the log of the http requests.
+
 ## [3.24.1] - 2024-04-10
 ### Fixed
 

--- a/lib/mangopay.rb
+++ b/lib/mangopay.rb
@@ -362,22 +362,5 @@ module MangoPay
     def logs_required?
       !configuration.log_file.nil? || !configuration.logger.nil?
     end
-
-    def filter_headers(hash, to_filter)
-      hash.each do |k,v|
-        if v.is_a?(Hash)
-          filter_hash(v, to_filter)
-        else
-          hash[k] = '[FILTERED]' if to_filter.include?(k)
-        end
-      end
-    end
-
-    def trace_headers_keys
-      @@trace_headers_keys ||= [
-        'Idempotency-Key', 'Traceparent', 'trace-id', 'X-Datadog-Trace-Id', 'X-Datadog-Parent-Id',
-        
-      ].freeze
-    end
   end
 end

--- a/lib/mangopay/version.rb
+++ b/lib/mangopay/version.rb
@@ -1,3 +1,3 @@
 module MangoPay
-  VERSION = '3.24.1'
+  VERSION = '3.25.0'
 end


### PR DESCRIPTION
Introduce the `log_trace_headers` boolean configuration key.
Set it to true to enable logging of `x_mangopay_trace-id` and `IdempotencyKey` in the log of the http requests.